### PR TITLE
dsh-desktop: add libstdc++ to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/bundles/web-ui/pnpm-workspace.json
+++ b/pkgs/bundles/web-ui/pnpm-workspace.json
@@ -1,9 +1,5 @@
 {
-  "packages": [
-    "shared",
-    "packages/*",
-    "packages/skins/*"
-  ],
+  "packages": ["shared", "packages/*", "packages/skins/*"],
   "autoInstallPeers": false,
   "linkWorkspacePackages": true,
   "allowBuilds": {

--- a/pkgs/dsh-desktop/package.nix
+++ b/pkgs/dsh-desktop/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   callPackage,
+  stdenv,
   stdenvNoCC,
   electron_43,
   makeWrapper,
@@ -82,7 +83,12 @@ stdenvNoCC.mkDerivation (
       gappsWrapperArgsHook
       makeWrapper "$appDir/DeepSeek Harness" "$out/bin/dsh-desktop" \
         "''${gappsWrapperArgs[@]}" \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libGL ]} \
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [
+            libGL
+            stdenv.cc.cc.lib
+          ]
+        } \
         ${runtimePathArgs}\
         --set CHROME_DEVEL_SANDBOX "${electron_43.unwrapped}/libexec/electron/chrome-sandbox" \
         --inherit-argv0


### PR DESCRIPTION
This change adds `stdenv.cc.cc.lib` to provide `libstdc++.so.6` to the wrapper's LD_LIBRARY_PATH for dsh-desktop.

On my NixOS configuration without existing libstdc++ in ld lib path, dsh-desktop fails to start due to "missing libstdc++...".

It has been tested and launches fine on my system now, shouldn't change anything for other systems or flake outputs.